### PR TITLE
change nonsystem header file's including style from system(<>) to user("...

### DIFF
--- a/vender/include/exlib/event.h
+++ b/vender/include/exlib/event.h
@@ -6,10 +6,10 @@
  *  lion@9465.net
  */
 
-#include <osconfig.h>
-
 #ifndef _ex_event_h__
 #define _ex_event_h__
+
+#include "osconfig.h"
 
 namespace exlib
 {

--- a/vender/include/exlib/fiber.h
+++ b/vender/include/exlib/fiber.h
@@ -6,12 +6,12 @@
  *  lion@9465.net
  */
 
-#include <osconfig.h>
-#include "event.h"
-#include "lockfree.h"
-
 #ifndef _ex_fiber_h__
 #define _ex_fiber_h__
+
+#include "osconfig.h"
+#include "event.h"
+#include "lockfree.h"
 
 namespace exlib
 {

--- a/vender/include/exlib/lockfree.h
+++ b/vender/include/exlib/lockfree.h
@@ -6,13 +6,14 @@
  *  lion@9465.net
  */
 
-#include "utils.h"
+#ifndef _ex_lockfree_h__
+#define _ex_lockfree_h__
+
 #ifndef _WIN32
 #include <unistd.h>
 #endif
 
-#ifndef _ex_lockfree_h__
-#define _ex_lockfree_h__
+#include "utils.h"
 
 namespace exlib
 {

--- a/vender/include/exlib/thread.h
+++ b/vender/include/exlib/thread.h
@@ -6,7 +6,10 @@
  *  lion@9465.net
  */
 
-#include <osconfig.h>
+#ifndef _ex_thread_h__
+#define _ex_thread_h__
+
+#include "osconfig.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -23,9 +26,6 @@
 
 #include <stdint.h>
 #include "utils.h"
-
-#ifndef _ex_thread_h__
-#define _ex_thread_h__
 
 namespace exlib
 {

--- a/vender/include/exlib/utils.h
+++ b/vender/include/exlib/utils.h
@@ -6,11 +6,11 @@
  *  lion@9465.net
  */
 
-#include "../osconfig.h"
-#include <stdint.h>
-
 #ifndef _ex_utils_h__
 #define _ex_utils_h__
+
+#include <stdint.h>
+#include "osconfig.h"
 
 #ifdef WIN32
 #include "utils_win.h"

--- a/vender/src/exlib/fiber/fbAsyncEvent.cpp
+++ b/vender/src/exlib/fiber/fbAsyncEvent.cpp
@@ -6,7 +6,7 @@
  *  lion@9465.net
  */
 
-#include <exlib/fiber.h>
+#include "exlib/fiber.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbCondVar.cpp
+++ b/vender/src/exlib/fiber/fbCondVar.cpp
@@ -6,7 +6,7 @@
  *  lion@9465.net
  */
 
-#include <exlib/fiber.h>
+#include "exlib/fiber.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbEvent.cpp
+++ b/vender/src/exlib/fiber/fbEvent.cpp
@@ -6,7 +6,7 @@
  *  lion@9465.net
  */
 
-#include <exlib/fiber.h>
+#include "exlib/fiber.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbFiber.cpp
+++ b/vender/src/exlib/fiber/fbFiber.cpp
@@ -6,13 +6,14 @@
  *  lion@9465.net
  */
 
-#include <osconfig.h>
-#include <exlib/fiber.h>
-#include <exlib/thread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <time.h>
+
+#include "osconfig.h"
+#include "exlib/fiber.h"
+#include "exlib/thread.h"
 
 #ifdef _WIN32
 #define WM_SLEEP    (WM_USER + 1)

--- a/vender/src/exlib/fiber/fbLocker.cpp
+++ b/vender/src/exlib/fiber/fbLocker.cpp
@@ -6,7 +6,7 @@
  *  lion@9465.net
  */
 
-#include <exlib/fiber.h>
+#include "exlib/fiber.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbSemaphore.cpp
+++ b/vender/src/exlib/fiber/fbSemaphore.cpp
@@ -6,7 +6,7 @@
  *  lion@9465.net
  */
 
-#include <exlib/fiber.h>
+#include "exlib/fiber.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbService.cpp
+++ b/vender/src/exlib/fiber/fbService.cpp
@@ -6,11 +6,12 @@
  *  lion@9465.net
  */
 
-#include <osconfig.h>
-#include <exlib/fiber.h>
-#include <exlib/thread.h>
 #include <string.h>
 #include <stdlib.h>
+
+#include "osconfig.h"
+#include "exlib/fiber.h"
+#include "exlib/thread.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbSwitch.cpp
+++ b/vender/src/exlib/fiber/fbSwitch.cpp
@@ -1,4 +1,4 @@
-#include <osconfig.h>
+#include "osconfig.h"
 
 #if defined(_MSC_VER) && defined(I386)
 

--- a/vender/src/exlib/fiber/fbTls.cpp
+++ b/vender/src/exlib/fiber/fbTls.cpp
@@ -6,8 +6,8 @@
  *  lion@9465.net
  */
 
-#include <exlib/fiber.h>
 #include <stdio.h>
+#include "exlib/fiber.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/fiber/fbUtils.cpp
+++ b/vender/src/exlib/fiber/fbUtils.cpp
@@ -7,9 +7,10 @@
 
 #ifdef WIN32
 
-#include <exlib/utils.h>
 #include <windows.h>
 #include <stdio.h>
+
+#include "exlib/utils.h"
 
 namespace exlib
 {

--- a/vender/src/exlib/thread.cpp
+++ b/vender/src/exlib/thread.cpp
@@ -6,8 +6,8 @@
  *  lion@9465.net
  */
 
-#include <exlib/thread.h>
 #include <stack>
+#include "exlib/thread.h"
 
 namespace exlib
 {


### PR DESCRIPTION
...") & etc.

有3点改动，请@xicilion Review并看看可否合并。
1. #ifndef _XXX_H_ #define _XXX_H_ 块移动到了顶上，应该可以少一点点编译时间
2. osconfig.h 和 exlib的头文件的include从<> 改到了 “”
3. 标准头文件的include提到了用户include的前面

在linux，mac，win(都是64bit）下编译过，看起来对别的没有影响。

另如果方便的话，可否全局性的对应一次？特别是(例如)`#inclue <zlib.h>`这种，看了下，tiff，gd等第三方库是用的`<zlib.h>`，在Linux下有可能需要特殊处理下，将本地的zlib的头文件路径设为系统路径，并放在默认系统路径的前面，否则有可能会和系统中已安装的开发包的版本出现冲突
