### PR TITLE
change build option to '-j(make jobs)' and '-v(verbose make)'

### DIFF
--- a/build
+++ b/build
@@ -1,36 +1,40 @@
 #!/bin/bash
 
-BUILD_JOBS=""
-eval BUILD_TYPE=\$$#
-
 usage()
 {
 	echo ""
-	echo "Usage: `basename $0` [-j] [-h] <Release | Release32 | Debug | Debug32 | clean>"
-	echo "  -j: enable make '-j' option. if set, will auto_detect core count and set make jobs to x2."
-	echo "  -h: print this and exit."
+	echo "Usage: `basename $0` <Release | Release32 | Debug | Debug32 | clean> [-j n|auto] [-v]"
+	echo "  -j: enable make '-j' option."
+	echo "      if 'auto' is gaven, will set jobs to auto detected core count, otherwise n is used."
+	echo "  -v: verbose make"
 	echo ""
 	exit 0
 }
+
+BUILD_TYPE=$1; shift 1;
+
+if [ "$BUILD_TYPE" = "" ]; then
+	usage
+fi
 
 if [ $BUILD_TYPE != 'Release' ] && [ $BUILD_TYPE != 'Release32' ] && [ $BUILD_TYPE != 'Debug' ] && [ $BUILD_TYPE != 'Debug32' ] && [ $BUILD_TYPE != 'clean' ]; then
 	usage
 fi
 
-while getopts :jh OPT
+while getopts j:v OPT
 do
     case $OPT in
-        j)  BUILD_JOBS=1
+        j)  BUILD_JOBS=$OPTARG
             ;;
-        h)  usage
+        v)  BUILD_VERBOSE='VERBOSE=V=1' 
             ;;
         \?) usage
             ;;
     esac
 done
-shift $((OPTIND - 1))
 
-if [ "$BUILD_JOBS" = "1" ]; then
+
+if [ "$BUILD_JOBS" = "auto" ]; then
 	#get cpu core count 
 	OS=$(uname)
 	CPU_CORE=1
@@ -50,17 +54,20 @@ if [ "$BUILD_JOBS" = "1" ]; then
 	if [ "$CPU_CORE" = "1" ]; then
 		BUILD_JOBS=""
 	else
-		# set build jobs with cpu core count * 2
-		BUILD_JOBS=`expr ${CPU_CORE} \* 2`
+		# set build jobs with cpu core count
+		BUILD_JOBS=${CPU_CORE}
 	fi
 fi
 
+export BUILD_JOBS
+export $BUILD_VERBOSE
+
 cd vender
-BUILD_JOBS=${BUILD_JOBS} sh build $BUILD_TYPE
+sh build $BUILD_TYPE
 cd ..
 
 cd fibjs
-BUILD_JOBS=${BUILD_JOBS} sh build $BUILD_TYPE
+sh build $BUILD_TYPE
 cd ..
 
 if [ $1 = 'clean' ]; then

--- a/fibjs/build
+++ b/fibjs/build
@@ -42,9 +42,9 @@ cd "out/${OS}_$1"
 cmake -DBUILD_TYPE=$1 -DGIT_INFO=$GIT_INFO ../../tools
 
 if [ ! "$BUILD_JOBS" = "" ]; then
-	make -j${BUILD_JOBS}
+	sh -c "${VERBOSE} make -j${BUILD_JOBS}"
 else
-	make
+	sh -c "${VERBOSE} make"
 fi
 
 if [ $1 = 'Release' ] || [ $1 = 'Release32' ]; then

--- a/vender/build
+++ b/vender/build
@@ -40,9 +40,9 @@ cd "out/${OS}_$1"
 cmake -DBUILD_TYPE=$1 ../../tools
 
 if [ ! "$BUILD_JOBS" = "" ]; then
-	make -j${BUILD_JOBS}
+	sh -c "${VERBOSE} make -j${BUILD_JOBS}"
 else
-	make
+	sh -c "${VERBOSE} make"
 fi
 
 cd ../..


### PR DESCRIPTION
根据[issue21](https://github.com/xicilion/fibjs/issues/21)做了如下变更，请Review & 评估可否合并，谢谢。
- 可选参数改为 -j，-v,
- 可选参数放置在 buildtype后面
- -j 如指定个数，使用指定个数，如指定为auto，使用发现的核心数
- -v 设置make的mode为verbose输出

``` base
$ ./build 

Usage: build <Release | Release32 | Debug | Debug32 | clean> [-j n|auto] [-v]
  -j: enable make '-j' option.
      if 'auto' is gaven, will set jobs to auto detected core count, otherwise n is used.
  -v: verbose make

```
