### PR TITLE
增加MongoDB支持64位整数类型

### DIFF
--- a/fibjs/include/Integer64.h
+++ b/fibjs/include/Integer64.h
@@ -1,0 +1,146 @@
+/*
+ * Integer64.h
+ *
+ *  Created on: Oct 31, 2012
+ *      Author: lion
+ */
+
+#include "ifs/Integer64.h"
+
+#ifndef INTEGER64_H_
+#define INTEGER64_H_
+
+static char __base64_map[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!*";
+
+namespace fibjs
+{
+
+class Integer64: public Integer64_base
+{
+public:
+    Integer64(const int64_t num) :
+        m_num(num)
+    {
+    }
+
+    Integer64(int64_t hi, int64_t lo)
+    {
+        m_num = ((hi & 0xffffffff) << 32) | (lo & 0xffffffff);
+    }
+
+public:
+    // Integer64_base
+    virtual result_t get_hi(int64_t& retVal)
+    {
+        retVal = (m_num >> 32);
+        return 0;
+    }
+    virtual result_t set_hi(int64_t newVal)
+    {
+        m_num = (m_num & 0xffffffff) | ((newVal & 0xffffffff) << 32);
+        return 0;
+    }
+    virtual result_t get_lo(int64_t& retVal)
+    {
+        retVal = (m_num & 0xffffffff);
+        return 0;
+    }
+    virtual result_t set_lo(int64_t newVal)
+    {
+        m_num = (m_num & 0xffffffff00000000) | (newVal & 0xffffffff);
+        return 0;
+    }
+    virtual result_t fromHex(const char* hexStr)
+    {
+        int pos = 0;
+        char cur = 0;
+        uint64_t newVal = 0;
+
+        while (pos < 16 && hexStr[pos]){
+            cur = hexStr[pos];
+            if (cur >= 48 && cur <= 57){
+                cur -= 48;
+            }else if (cur >= 65 && cur <= 70){
+                cur -= 55;
+            }else if (cur >= 97 && cur <= 102){
+                cur -= 87;
+            }else {
+                break;
+            }
+            newVal = (newVal << 4) + cur;
+            pos++;
+        }
+        m_num = (int64_t)newVal;
+
+        return 0;
+    }
+    virtual result_t fromString(const char* numStr, int32_t base)
+    {
+        int pos = 0;
+        char cur = 0;
+        uint64_t newVal = 0;
+
+        while (pos < 64 && numStr[pos]){
+            cur = numStr[pos];
+            if (cur >= 48 && cur <= 57){
+                cur -= 48;
+            }else if (cur >= 65 && cur <= 70){
+                cur -= 55;
+            }else if (cur >= 97 && cur <= 102){
+                cur -= 61;
+            }else if (cur == '!'){
+                cur = 62;
+            }else if (cur == '*'){
+                cur = 63;
+            }else {
+                break;
+            }
+            newVal = (newVal *base) + cur;
+            pos++;
+        }
+        m_num = (int64_t)newVal;
+
+        return 0;
+    }
+    virtual result_t toString(int32_t base, std::string& retVal)
+    {
+        char buf[64] = {0};
+        int pos = 64;
+        uint64_t val = (uint64_t)m_num;
+
+        if (base < 2 || base > 64){
+            return 0;
+        }
+
+        while (pos > 0 && val > 0){
+            buf[--pos] = __base64_map[val % base];
+            val /= base;
+        }
+        retVal.assign(buf+pos, 64-pos);
+
+        return 0;
+    }
+
+    virtual result_t valueOf(double& retVal)
+    {
+        retVal = (double) m_num;
+        return 0;
+    }
+
+    virtual result_t toJSON(const char *key, v8::Local<v8::Value> &retVal)
+    {
+        std::string str;
+
+        toString(64, str);
+        retVal = v8::String::NewFromUtf8(isolate, str.c_str(),
+                    v8::String::kNormalString, (int) str.length());
+
+        return 0;
+    }
+
+public:
+    int64_t m_num;
+};
+
+} /* namespace fibjs */
+#endif /* INTEGER64_H_ */

--- a/fibjs/include/ifs/Integer64.h
+++ b/fibjs/include/ifs/Integer64.h
@@ -1,0 +1,194 @@
+/***************************************************************************
+ *                                                                         *
+ *   This file was automatically generated using idlc.js                   *
+ *   PLEASE DO NOT EDIT!!!!                                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef _Integer64_base_H_
+#define _Integer64_base_H_
+
+/**
+ @author Leo Hoo <lion@9465.net>
+ */
+
+#include "../object.h"
+
+namespace fibjs
+{
+
+class Integer64_base : public object_base
+{
+public:
+	// Integer64_base
+	virtual result_t get_hi(int64_t& retVal) = 0;
+	virtual result_t set_hi(int64_t newVal) = 0;
+	virtual result_t get_lo(int64_t& retVal) = 0;
+	virtual result_t set_lo(int64_t newVal) = 0;
+	virtual result_t fromHex(const char* hexStr) = 0;
+	virtual result_t fromString(const char* numStr, int32_t base) = 0;
+	virtual result_t toString(int32_t base, std::string& retVal) = 0;
+	virtual result_t valueOf(double& retVal) = 0;
+	virtual result_t toJSON(const char* key, v8::Local<v8::Value>& retVal) = 0;
+
+	DECLARE_CLASSINFO(Integer64_base);
+
+public:
+	static void s_get_hi(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value> &args);
+	static void s_set_hi(v8::Local<v8::String> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &args);
+	static void s_get_lo(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value> &args);
+	static void s_set_lo(v8::Local<v8::String> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &args);
+	static void s_fromHex(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void s_fromString(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void s_toString(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void s_valueOf(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void s_toJSON(const v8::FunctionCallbackInfo<v8::Value>& args);
+};
+
+}
+
+namespace fibjs
+{
+	inline ClassInfo& Integer64_base::class_info()
+	{
+		static ClassData::ClassMethod s_method[] = 
+		{
+			{"fromHex", s_fromHex},
+			{"fromString", s_fromString},
+			{"toString", s_toString},
+			{"valueOf", s_valueOf},
+			{"toJSON", s_toJSON}
+		};
+
+		static ClassData::ClassProperty s_property[] = 
+		{
+			{"hi", s_get_hi, s_set_hi},
+			{"lo", s_get_lo, s_set_lo}
+		};
+
+		static ClassData s_cd = 
+		{ 
+			"Integer64", NULL, 
+			5, s_method, 0, NULL, 2, s_property, NULL, NULL,
+			&object_base::class_info()
+		};
+
+		static ClassInfo s_ci(s_cd);
+		return s_ci;
+	}
+
+	inline void Integer64_base::s_get_hi(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value> &args)
+	{
+		int64_t vr;
+
+		PROPERTY_ENTER();
+		PROPERTY_INSTANCE(Integer64_base);
+
+		hr = pInst->get_hi(vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void Integer64_base::s_set_hi(v8::Local<v8::String> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &args)
+	{
+		PROPERTY_ENTER();
+		PROPERTY_INSTANCE(Integer64_base);
+
+		PROPERTY_VAL(int64_t);
+		hr = pInst->set_hi(v0);
+
+		PROPERTY_SET_LEAVE();
+	}
+
+	inline void Integer64_base::s_get_lo(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value> &args)
+	{
+		int64_t vr;
+
+		PROPERTY_ENTER();
+		PROPERTY_INSTANCE(Integer64_base);
+
+		hr = pInst->get_lo(vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void Integer64_base::s_set_lo(v8::Local<v8::String> property, v8::Local<v8::Value> value, const v8::PropertyCallbackInfo<void> &args)
+	{
+		PROPERTY_ENTER();
+		PROPERTY_INSTANCE(Integer64_base);
+
+		PROPERTY_VAL(int64_t);
+		hr = pInst->set_lo(v0);
+
+		PROPERTY_SET_LEAVE();
+	}
+
+	inline void Integer64_base::s_fromHex(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		METHOD_INSTANCE(Integer64_base);
+		METHOD_ENTER(1, 0);
+
+		OPT_ARG(arg_string, 0, "");
+
+		hr = pInst->fromHex(v0);
+
+		METHOD_VOID();
+	}
+
+	inline void Integer64_base::s_fromString(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		METHOD_INSTANCE(Integer64_base);
+		METHOD_ENTER(2, 0);
+
+		OPT_ARG(arg_string, 0, "");
+		OPT_ARG(int32_t, 1, 64);
+
+		hr = pInst->fromString(v0, v1);
+
+		METHOD_VOID();
+	}
+
+	inline void Integer64_base::s_toString(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		std::string vr;
+
+		METHOD_INSTANCE(Integer64_base);
+		METHOD_ENTER(1, 0);
+
+		OPT_ARG(int32_t, 0, 64);
+
+		hr = pInst->toString(v0, vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void Integer64_base::s_valueOf(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		double vr;
+
+		METHOD_INSTANCE(Integer64_base);
+		METHOD_ENTER(0, 0);
+
+		hr = pInst->valueOf(vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void Integer64_base::s_toJSON(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		v8::Local<v8::Value> vr;
+
+		METHOD_INSTANCE(Integer64_base);
+		METHOD_ENTER(1, 1);
+
+		ARG(arg_string, 0);
+
+		hr = pInst->toJSON(v0, vr);
+
+		METHOD_RETURN();
+	}
+
+}
+
+#endif
+

--- a/fibjs/include/ifs/Integer64.idl
+++ b/fibjs/include/ifs/Integer64.idl
@@ -1,0 +1,36 @@
+/*! @brief mongodb 数据库NumberLong类型64位整数 */
+class Integer64: object
+{
+    /*! @brief 高 32 位数值 */
+    Long hi;
+
+    /*! @brief 低 32 位数值 */
+    Long lo;
+
+    /*! @brief 设置 16 进制HEX字符串更新对象的值
+      @param hexStr 16 进制字符串
+     */
+    fromHex(String hexStr = "");
+
+    /*! @brief 使用字符串转换为对应的整数
+      @param numStr 数字字符串默认为64进制
+      @param base 字符串进制数
+     */
+    fromString(String numStr = "", Integer base = 64);
+
+    /*! @brief 转换成字符串类型
+      @param base 字符串进制数默认为64
+      @return 返回转换后的字符串
+     */
+    String toString(Integer base = 64);
+
+    /*! @brief 转化为整型数字类型
+      @return 返回整数数值
+     */
+    Number valueOf();
+
+    /*! @brief 对象转换为JSON数据
+      @return 返回JSON转换结果
+     */
+    Value toJSON(String key);
+};

--- a/fibjs/include/ifs/global.h
+++ b/fibjs/include/ifs/global.h
@@ -21,12 +21,16 @@ namespace fibjs
 class module_base;
 class Buffer_base;
 class console_base;
+class Integer64_base;
 
 class global_base : public module_base
 {
 public:
 	// global_base
 	static result_t get_console(obj_ptr<console_base>& retVal);
+	static result_t int64(int64_t hi, int64_t lo, obj_ptr<Integer64_base>& retVal);
+	static result_t int64String(const char* num, double base, obj_ptr<Integer64_base>& retVal);
+	static result_t int64Hex(const char* hex, obj_ptr<Integer64_base>& retVal);
 	static result_t run(const char* fname);
 	static result_t require(const char* id, v8::Local<v8::Value>& retVal);
 	static result_t GC();
@@ -35,6 +39,9 @@ public:
 
 public:
 	static void s_get_console(v8::Local<v8::String> property, const v8::PropertyCallbackInfo<v8::Value> &args);
+	static void s_int64(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void s_int64String(const v8::FunctionCallbackInfo<v8::Value>& args);
+	static void s_int64Hex(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void s_run(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void s_require(const v8::FunctionCallbackInfo<v8::Value>& args);
 	static void s_GC(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -44,6 +51,7 @@ public:
 
 #include "Buffer.h"
 #include "console.h"
+#include "Integer64.h"
 
 namespace fibjs
 {
@@ -51,6 +59,9 @@ namespace fibjs
 	{
 		static ClassData::ClassMethod s_method[] = 
 		{
+			{"int64", s_int64, true},
+			{"int64String", s_int64String, true},
+			{"int64Hex", s_int64Hex, true},
 			{"run", s_run, true},
 			{"require", s_require, true},
 			{"GC", s_GC, true}
@@ -69,7 +80,7 @@ namespace fibjs
 		static ClassData s_cd = 
 		{ 
 			"global", NULL, 
-			3, s_method, 1, s_object, 1, s_property, NULL, NULL,
+			6, s_method, 1, s_object, 1, s_property, NULL, NULL,
 			&module_base::class_info()
 		};
 
@@ -84,6 +95,47 @@ namespace fibjs
 		PROPERTY_ENTER();
 
 		hr = get_console(vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void global_base::s_int64(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		obj_ptr<Integer64_base> vr;
+
+		METHOD_ENTER(2, 0);
+
+		OPT_ARG(int64_t, 0, 0);
+		OPT_ARG(int64_t, 1, 0);
+
+		hr = int64(v0, v1, vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void global_base::s_int64String(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		obj_ptr<Integer64_base> vr;
+
+		METHOD_ENTER(2, 0);
+
+		OPT_ARG(arg_string, 0, "");
+		OPT_ARG(double, 1, 64);
+
+		hr = int64String(v0, v1, vr);
+
+		METHOD_RETURN();
+	}
+
+	inline void global_base::s_int64Hex(const v8::FunctionCallbackInfo<v8::Value>& args)
+	{
+		obj_ptr<Integer64_base> vr;
+
+		METHOD_ENTER(1, 0);
+
+		OPT_ARG(arg_string, 0, "");
+
+		hr = int64Hex(v0, vr);
 
 		METHOD_RETURN();
 	}

--- a/fibjs/include/ifs/global.idl
+++ b/fibjs/include/ifs/global.idl
@@ -8,6 +8,26 @@ class global : module
     /*! @brief 控制台访问对象 */
     static readonly console console;
 
+    /*! @brief 通过两个32位数组合生成一个Int64对象
+     @param hi 高32位数
+     @param lo 低32位数
+     @return 返回生成的对象
+     */
+    static Integer64 int64(Long hi = 0, Long lo = 0);
+
+    /*! @brief 通过字符串转换生成一个Int64对象
+     @param num 数字字符串
+     @param base 数字字符串的进制数默认为64
+     @return 返回生成的对象
+     */
+    static Integer64 int64String(String num = "", Number base = 64);
+
+    /*! @brief 转换一个16进制字符串生成一个Int64对象
+     @param hex 16进制字符串
+     @return 返回生成的对象
+     */
+    static Integer64 int64Hex(String hex = "");
+
     /*! @brief 运行一个脚本
      @param fname 指定要运行的脚本路径
      */

--- a/fibjs/src/encoding_bson.cpp
+++ b/fibjs/src/encoding_bson.cpp
@@ -9,6 +9,7 @@
 #include "ifs/encoding.h"
 #include "Buffer.h"
 #include "MongoID.h"
+#include "Integer64.h"
 
 namespace fibjs
 {
@@ -73,6 +74,19 @@ void encodeValue(bson *bb, const char *name, v8::Local<v8::Value> element,
     }
     else if (element->IsObject())
     {
+        {
+            obj_ptr<Integer64> num = (Integer64 *)Integer64_base::getInstance(element);
+
+            if (num)
+            {
+                if (num->m_num >= -2147483648ll && num->m_num <= 2147483647ll)
+                    bson_append_int(bb, name, (int) num->m_num);
+                else
+                    bson_append_long(bb, name, num->m_num);
+                return;
+            }
+        }
+
         {
             obj_ptr<Buffer_base> buf = Buffer_base::getInstance(element);
 
@@ -252,9 +266,17 @@ void decodeValue(v8::Local<v8::Object> obj, bson_iterator *it)
         obj->Set(v8::String::NewFromUtf8(isolate, key), v8::Number::New(isolate, bson_iterator_int(it)));
         break;
     case BSON_LONG:
-        obj->Set(v8::String::NewFromUtf8(isolate, key),
-                 v8::Number::New(isolate, (double) bson_iterator_long(it)));
+    {
+        int64_t num = bson_iterator_long(it);
+        if (num >= -2147483648ll && num <= 2147483647ll){
+          obj->Set(v8::String::NewFromUtf8(isolate, key),
+                 v8::Number::New(isolate, (double) num));
+        }else {
+            obj_ptr<Integer64> int64 = new Integer64(num);
+            obj->Set(v8::String::NewFromUtf8(isolate, key), int64->wrap());
+        }
         break;
+    }
     case BSON_DOUBLE:
         obj->Set(v8::String::NewFromUtf8(isolate, key),
                  v8::Number::New(isolate, bson_iterator_double(it)));

--- a/fibjs/src/global.cpp
+++ b/fibjs/src/global.cpp
@@ -2,6 +2,7 @@
 #include "ifs/coroutine.h"
 #include "ifs/vm.h"
 #include "SandBox.h"
+#include "Integer64.h"
 
 namespace fibjs
 {
@@ -33,6 +34,26 @@ result_t global_base::run(const char *fname)
 result_t global_base::require(const char *id, v8::Local<v8::Value> &retVal)
 {
     return s_topSandbox->require(id, retVal);
+}
+
+result_t global_base::int64(int64_t hi, int64_t lo, obj_ptr<Integer64_base>& retVal)
+{
+    retVal = new Integer64(hi, lo);
+    return 0;
+}
+
+result_t global_base::int64String(const char* num, double base, obj_ptr<Integer64_base>& retVal)
+{
+	retVal = new Integer64(0);
+	(Integer64) retVal->fromString(num, base);
+	return 0;
+}
+
+result_t global_base::int64Hex(const char* hex, obj_ptr<Integer64_base>& retVal)
+{
+	retVal = new Integer64(0);
+	(Integer64) retVal->fromHex(hex);
+	return 0;
 }
 
 }


### PR DESCRIPTION
增加Integer64的内部对象类型, Mongo的NumberLong类型自动判断大小决定使用Number还是Integer64对象类型返回.
字符串类型使用了大小写区分的形式, 64个字符尽量减少表示64位整数所需要的字符数量.
带有ValueOf函数, 可以支持数字的加减运算, 由于js的double类型的精度丢失, 进行运算的时候超限度的时候还是会有问题吧.
感觉最好是能在mongo对象加配置, 可以限制是否使用内置对象类型表示Int64的整数类型.
