### PR TITLE
check if htonll is defined before redefining

### DIFF
--- a/vender/zookeeper/include/recordio.h
+++ b/vender/zookeeper/include/recordio.h
@@ -73,7 +73,9 @@ void close_buffer_iarchive(struct iarchive **ia);
 char *get_buffer(struct oarchive *);
 int get_buffer_len(struct oarchive *);
 
+#ifndef htonll
 int64_t htonll(int64_t v);
+#endif
 
 #ifdef __cplusplus
 }

--- a/vender/zookeeper/src/recordio.c
+++ b/vender/zookeeper/src/recordio.c
@@ -80,6 +80,7 @@ int oa_serialize_int(struct oarchive *oa, const char *tag, const int32_t *d)
     priv->off+=sizeof(i);
     return 0;
 }
+#ifndef htonll
 int64_t htonll(int64_t v)
 {
     int i = 0;
@@ -95,6 +96,7 @@ int64_t htonll(int64_t v)
 
     return v;
 }
+#endif
 
 int oa_serialize_long(struct oarchive *oa, const char *tag, const int64_t *d)
 {


### PR DESCRIPTION
Fixes Yosemite build issue (https://github.com/xicilion/fibjs/issues/31)
