### PR TITLE
[test] process case: using PATH environment variable

### DIFF
--- a/test/process_test.js
+++ b/test/process_test.js
@@ -175,6 +175,13 @@ describe('process', () => {
         assert.ok(process.version);
     });
 
+    if (process.platform === "linux" || process.platform === "darwin") {
+        it("PATH env", () => {
+            assert.equal(process.run("ls", ["./process"]), 0)
+            assert.ok(process.open("ls", ["-a", "./process"]).stdout.readLine());
+        });
+    }
+
     if (process.platform != "win32")
         it("umask()", () => {
             const mask = '0664';


### PR DESCRIPTION
`process.run()` and `process.open()` using PATH environment variable instead of using absolute path.

Current error message

```
Error: [2] No such file or directory
    ...
```