### PR TITLE
core, feat: enable modify the built-in object in strict mode

### DIFF
--- a/fibjs/include/ClassInfo.h
+++ b/fibjs/include/ClassInfo.h
@@ -199,8 +199,7 @@ public:
 
                 if (!skips || !skips[j])
                     o->DefineOwnProperty(_context, isolate->NewFromUtf8(m_cd.cms[i].name),
-                         isolate->NewFunction(m_cd.name, m_cd.cms[i].invoker),
-                         (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+                         isolate->NewFunction(m_cd.name, m_cd.cms[i].invoker))
                         .IsJust();
             }
         }
@@ -212,8 +211,7 @@ public:
 
             if (!skips || !skips[j])
                 o->DefineOwnProperty(_context, isolate->NewFromUtf8(m_cd.cos[i].name),
-                     m_cd.cos[i].invoker().getModule(isolate),
-                     (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+                     m_cd.cos[i].invoker().getModule(isolate))
                     .IsJust();
         }
 
@@ -316,14 +314,12 @@ private:
 
             for (i = 0; i < m_cd.mc; i++)
                 pt->Set(isolate->NewFromUtf8(m_cd.cms[i].name),
-                    v8::FunctionTemplate::New(isolate->m_isolate, m_cd.cms[i].invoker),
-                    (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete));
+                    v8::FunctionTemplate::New(isolate->m_isolate, m_cd.cms[i].invoker));
 
             for (i = 0; i < m_cd.oc; i++) {
                 cache* _cache1 = m_cd.cos[i].invoker()._init(isolate);
                 pt->Set(isolate->NewFromUtf8(m_cd.cos[i].name),
-                    v8::Local<v8::FunctionTemplate>::New(isolate->m_isolate, _cache1->m_class),
-                    (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete));
+                    v8::Local<v8::FunctionTemplate>::New(isolate->m_isolate, _cache1->m_class));
             }
 
             for (i = 0; i < m_cd.pc; i++)

--- a/fibjs/src/test/test.cpp
+++ b/fibjs/src/test/test.cpp
@@ -465,67 +465,52 @@ result_t test_base::setup()
     v8::Local<v8::Function> func, func1;
 
     glob->DefineOwnProperty(_context, isolate->NewFromUtf8("assert"),
-            assert_base::class_info().getModule(isolate),
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+            assert_base::class_info().getModule(isolate))
         .IsJust();
 
     func = isolate->NewFunction("describe", s_describe);
-    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("describe"), func,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("describe"), func)
         .IsJust();
 
     func1 = isolate->NewFunction("xdescribe", s_xdescribe);
-    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("xdescribe"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("xdescribe"), func1)
         .IsJust();
-    func->DefineOwnProperty(_context, isolate->NewFromUtf8("skip"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    func->DefineOwnProperty(_context, isolate->NewFromUtf8("skip"), func1)
         .IsJust();
 
     func1 = isolate->NewFunction("odescribe", s_odescribe);
-    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("odescribe"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("odescribe"), func1)
         .IsJust();
-    func->DefineOwnProperty(_context, isolate->NewFromUtf8("only"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    func->DefineOwnProperty(_context, isolate->NewFromUtf8("only"), func1)
         .IsJust();
 
     func = isolate->NewFunction("it", s_it);
-    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("it"), func,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("it"), func)
         .IsJust();
 
     func1 = isolate->NewFunction("xit", s_xit);
-    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("xit"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("xit"), func1)
         .IsJust();
-    func->DefineOwnProperty(_context, isolate->NewFromUtf8("skip"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    func->DefineOwnProperty(_context, isolate->NewFromUtf8("skip"), func1)
         .IsJust();
 
     func1 = isolate->NewFunction("oit", s_oit);
-    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("oit"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    glob->DefineOwnProperty(_context, isolate->NewFromUtf8("oit"), func1)
         .IsJust();
-    func->DefineOwnProperty(_context, isolate->NewFromUtf8("only"), func1,
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+    func->DefineOwnProperty(_context, isolate->NewFromUtf8("only"), func1)
         .IsJust();
 
     glob->DefineOwnProperty(_context, isolate->NewFromUtf8("before"),
-            isolate->NewFunction("before", s_before),
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+            isolate->NewFunction("before", s_before))
         .IsJust();
     glob->DefineOwnProperty(_context, isolate->NewFromUtf8("after"),
-            isolate->NewFunction("after", s_after),
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+            isolate->NewFunction("after", s_after))
         .IsJust();
     glob->DefineOwnProperty(_context, isolate->NewFromUtf8("beforeEach"),
-            isolate->NewFunction("beforeEach", s_beforeEach),
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+            isolate->NewFunction("beforeEach", s_beforeEach))
         .IsJust();
     glob->DefineOwnProperty(_context, isolate->NewFromUtf8("afterEach"),
-            isolate->NewFunction("afterEach", s_afterEach),
-            (v8::PropertyAttribute)(v8::ReadOnly | v8::DontDelete))
+            isolate->NewFunction("afterEach", s_afterEach))
         .IsJust();
 
     return 0;


### PR DESCRIPTION
in strict mode, code like this, won't throw an error.

```js
'use strict';

console.log = () => {};
```
