### PR TITLE
core, feat:treat NaN as zero in argumets when require number

### DIFF
--- a/fibjs/include/utils.h
+++ b/fibjs/include/utils.h
@@ -576,8 +576,7 @@ inline result_t GetArgumentValue(v8::Local<v8::Value> v, double& n, bool bStrict
     }
 
     n = v->NumberValue();
-    if (isnan(n))
-        return CALL_E_TYPEMISMATCH;
+    if (isnan(n)) n = 0;
 
     return 0;
 }

--- a/fibjs/include/utils.h
+++ b/fibjs/include/utils.h
@@ -571,8 +571,6 @@ inline result_t GetArgumentValue(v8::Local<v8::Value> v, double& n, bool bStrict
             return CALL_E_TYPEMISMATCH;
 
         v = v->ToNumber();
-        if (v.IsEmpty())
-            return CALL_E_TYPEMISMATCH;
     }
 
     n = v->NumberValue();

--- a/test/buffer_test.js
+++ b/test/buffer_test.js
@@ -818,15 +818,15 @@ describe('Buffer', () => {
         assert.doesNotThrow(() => {
             buf.resize("12")
         });
-        assert.throws(() => {
+        assert.doesNotThrow(() => {
             buf.resize("a12")
         });
 
-        assert.throws(() => {
+        assert.doesNotThrow(() => {
             buf.resize("12a")
         });
 
-        assert.throws(() => {
+        assert.doesNotThrow(() => {
             buf.resize("12.a")
         });
     });

--- a/test/console_test.js
+++ b/test/console_test.js
@@ -42,11 +42,19 @@ describe("console", () => {
             levels: [console.DEBUG, console.ERROR]
         });
 
-        assert.throws(() => {
-            console.add({
-                type: "console",
-                levels: [console.DEBUG, "other"]
-            });
+        console.add({
+            type: "console",
+            levels: [console.DEBUG, {}]
+        });
+
+        console.add({
+            type: "console",
+            levels: [console.DEBUG, NaN]
+        });
+
+        console.add({
+            type: "console",
+            levels: [console.DEBUG, '1']
         });
 
         assert.throws(() => {

--- a/test/int64_test.js
+++ b/test/int64_test.js
@@ -17,12 +17,6 @@ describe('Int64', () => {
         assert.equal(k.toString(16), '0xfedcba9876543210');
     });
 
-    it('can not be constructed from object', () => {
-        assert.throws(() => {
-            var x = new Int64({});
-        });
-    });
-
     it('can be compared', () => {
         var a = new Int64(2),
             b = new Int64(3);


### PR DESCRIPTION
In ES, all the Number param accept all kinds of value. The Value will be first coerced to a number.Any arguments that coerce to NaN, like 'string', {}, null or undefined, will be coerced to zero.
