### PR TITLE
websocket, feat: support add customized http headers

### DIFF
--- a/fibjs/include/ifs/WebSocket.h
+++ b/fibjs/include/ifs/WebSocket.h
@@ -26,6 +26,7 @@ class WebSocket_base : public EventEmitter_base {
 public:
     // WebSocket_base
     static result_t _new(exlib::string url, exlib::string protocol, exlib::string origin, obj_ptr<WebSocket_base>& retVal, v8::Local<v8::Object> This = v8::Local<v8::Object>());
+    static result_t _new(exlib::string url, v8::Local<v8::Object> opts, obj_ptr<WebSocket_base>& retVal, v8::Local<v8::Object> This = v8::Local<v8::Object>());
     virtual result_t get_url(exlib::string& retVal) = 0;
     virtual result_t get_protocol(exlib::string& retVal) = 0;
     virtual result_t get_origin(exlib::string& retVal) = 0;
@@ -123,6 +124,13 @@ void WebSocket_base::__new(const T& args)
     OPT_ARG(exlib::string, 2, "");
 
     hr = _new(v0, v1, v2, vr, args.This());
+
+    METHOD_OVER(2, 1);
+
+    ARG(exlib::string, 0);
+    OPT_ARG(v8::Local<v8::Object>, 1, v8::Object::New(isolate));
+
+    hr = _new(v0, v1, vr, args.This());
 
     CONSTRUCT_RETURN();
 }

--- a/fibjs/src/http/http.cpp
+++ b/fibjs/src/http/http.cpp
@@ -39,6 +39,16 @@ result_t http_request(exlib::string method, exlib::string url,
     return get_httpClient(ac->isolate())->request(method, url, body, headers, retVal, ac);
 }
 
+result_t http_request2(HttpClient_base* httpClient, exlib::string method, exlib::string url,
+    SeekableStream_base* body, NObject* headers,
+    obj_ptr<HttpResponse_base>& retVal, AsyncEvent* ac)
+{
+    if (httpClient != NULL)
+        return ((HttpClient*)httpClient)->request(method, url, body, headers, retVal, ac);
+    else
+        return get_httpClient(ac->isolate())->request(method, url, body, headers, retVal, ac);
+}
+
 result_t http_base::get_cookies(obj_ptr<NArray>& retVal)
 {
     return get_httpClient()->get_cookies(retVal);

--- a/idl/zh-cn/WebSocket.idl
+++ b/idl/zh-cn/WebSocket.idl
@@ -30,9 +30,19 @@ interface WebSocket : EventEmitter
     /*! @brief WebSocket 构造函数
      @param url 指定连接的服务器
      @param protocol 指定握手协议，缺省为 ""
-     @param origin 指定握手时模拟的源
+     @param origin 指定握手时模拟的源，缺省为 ""
     */
     WebSocket(String url, String protocol = "", String origin = "");
+    
+    /*! @brief WebSocket 构造函数
+     @param url 指定连接的服务器
+     @param opts 连接选项，缺省是 {}，支持的字段有 "protocol", "origin", "headers", "httpClient"。 
+     其中 protocol 指定握手协议，缺省为 ""，
+     origin 指定握手时模拟的源，缺省为 ""，
+     headers 是 http(s) 连接时携带的 header 缺省为 {}，
+     httpClient 使用指定 httpClient 实例的 cookie，缺省为 undefined 默认使用全局 cookie，参见 HttpClient
+    */
+    WebSocket(String url, Object opts = {});
 
     /*! @brief 查询当前对象连接的服务器 */
     readonly String url;


### PR DESCRIPTION
 Websocket in browser can carry no http headers other than cookies. This feature makes it easy for websocket server to identify the validity of the client in Mq.Chain before upgraded to ws.
Support isolate httpClient.