### PR TITLE
[WIP]assert, bugfix: avoid crash when read object's field value whose `getter` maybe throw expection

### DIFF
--- a/fibjs/src/test/assert.cpp
+++ b/fibjs/src/test/assert.cpp
@@ -785,8 +785,15 @@ result_t has_val(v8::Local<v8::Value> object, v8::Local<v8::Value> prop,
         return CHECK_ERROR(CALL_E_INVALIDARG);
 
     v8::Local<v8::Object> v = object->ToObject();
+    
+    TryCatch try_catch;
     got = v->Get(prop);
-    retVal = value->Equals(got);
+    if (got.IsEmpty()) {
+        ReportException(try_catch, 0);
+        retVal = false;
+    } else {
+        retVal = value->Equals(got);
+    }
 
     return 0;
 }
@@ -838,9 +845,15 @@ result_t deep_has_val(v8::Local<v8::Value> object, v8::Local<v8::Value> prop,
 
     p = ToCString(s);
     while ((p1 = qstrchr(p, '.')) != NULL) {
+        TryCatch try_catch;
         object = v->Get(isolate->NewString(p, (int32_t)(p1 - p)));
+        if (object.IsEmpty()) {
+            ReportException(try_catch, 0);
+            retVal = false;
+            return 0;
+        }
 
-        if (object.IsEmpty() || (!object->IsObject() && !object->IsString())) {
+        if ((!object->IsObject() && !object->IsString())) {
             retVal = false;
             return 0;
         }
@@ -849,8 +862,14 @@ result_t deep_has_val(v8::Local<v8::Value> object, v8::Local<v8::Value> prop,
         p = p1 + 1;
     }
 
+    TryCatch try_catch;
     got = v->Get(isolate->NewString(p));
-    retVal = value->Equals(got);
+    if (got.IsEmpty()) {
+        ReportException(try_catch, 0);
+        retVal = false;
+    } else {
+        retVal = value->Equals(got);
+    }
 
     return 0;
 }

--- a/fibjs/src/util/util_format.cpp
+++ b/fibjs/src/util/util_format.cpp
@@ -232,7 +232,14 @@ exlib::string json_format(v8::Local<v8::Value> obj)
                 if (len == 0)
                     strBuffer.append("{}");
                 else {
-                    if (len == 1 && v->StrictEquals(obj->Get(keys->Get(0))))
+                    TryCatch try_catch;
+                    v8::Local<v8::Value> _v = obj->Get(keys->Get(0));
+                    if (_v.IsEmpty()) {
+                        ReportException(try_catch, 0);
+                        continue ;
+                    }
+                    
+                    if (len == 1 && v->StrictEquals(_v))
                         strBuffer.append("[Circular]");
                     else {
                         stk.resize(sz + 1);

--- a/test/assert_test.js
+++ b/test/assert_test.js
@@ -468,6 +468,38 @@ describe('assert', () => {
         }, "expected { foo: { bar: 'baz' } } to not have a deep property 'foo.bar' of 'baz'");
     });
 
+    it("exception - propertyVal", () => {
+        const test = { get abc () { throw 'I am exception' } }
+        assert.property(test, 'abc')
+
+        assert.throws(() => {
+            assert.propertyVal(test, 'abc', undefined)
+        }, `expected  to have a property "abc" of undefined, but got undefined`);
+    });
+
+    it("exception - propertyNotVal", () => {
+        const test = { get abc () { throw 'I am exception' } }
+
+        assert.propertyNotVal(test, 'abc', undefined)
+        assert.propertyNotVal(test, 'abc', null)
+    });
+
+    it("exception - deepPropertyVal", () => {
+        const test = { a: { get bc () { throw 'I am deep Exception' } } }
+        assert.deepProperty(test, 'a.bc')
+
+        assert.throws(() => {
+            assert.deepPropertyVal(test, 'a.bc', undefined)
+        }, `expected { "a": } to have a deep property "a.bc" of undefined, but got undefined`);
+    });
+
+    it("exception - deepPropertyNotVal", () => {
+        const test = { a: { get bc () { throw 'I am deep Exception' } } }
+
+        assert.deepPropertyNotVal(test, 'a.bc', undefined)
+        assert.deepPropertyNotVal(test, 'a.bc', null)
+    });
+
     it('throws', () => {
         assert.throws(() => {
             throw new Error('foo');


### PR DESCRIPTION
Please fill in this template.

- [ ] Use a meaningful title for the pull request with prefix '(module|object|source_directory) [bugfix|feat|refactor|]', Such as `db, bugfix: ...`, `tools, feat: ...`
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `fibjs test`.)
- [x] Ensure commits history clean, merge master/dev and clean meaningless commits by `git rebase`.