### PR TITLE
msgpack, bugfix: stringObject and BooleanObject are incorrectly encoded as Object

### DIFF
--- a/fibjs/src/encoding/encoding_msgpack.cpp
+++ b/fibjs/src/encoding/encoding_msgpack.cpp
@@ -36,8 +36,8 @@ result_t msgpack_base::encode(v8::Local<v8::Value> data, obj_ptr<Buffer_base>& r
                 return CHECK_ERROR(CALL_E_BADVARTYPE);
             else if (element->IsNull() || element->IsUndefined())
                 msgpack_pack_nil(&pk);
-            else if (element->IsBoolean()) {
-                if (element->IsTrue())
+            else if (element->IsBoolean() || element->IsBooleanObject()) {
+                if (element->BooleanValue())
                     msgpack_pack_true(&pk);
                 else
                     msgpack_pack_false(&pk);
@@ -51,7 +51,7 @@ result_t msgpack_base::encode(v8::Local<v8::Value> data, obj_ptr<Buffer_base>& r
                 msgpack_pack_timestamp(&pk, &_d);
             } else if (element->IsArray())
                 return pack(v8::Local<v8::Array>::Cast(element));
-            else if (element->IsObject())
+            else if (element->IsObject() && !element->IsStringObject())
                 return pack(element->ToObject());
             else {
                 v8::String::Utf8Value v(element);

--- a/test/encoding_test.js
+++ b/test/encoding_test.js
@@ -584,6 +584,24 @@ describe('encoding', () => {
             };
             assert.deepEqual(expect, msgpack.decode(msgpack.encode(subject)));
         });
+        
+        it('test primitive bool / new Boolean()', ()=> {
+        	var obj1 = {'b1': true,             };
+        	var obj2 = {'b1': new Boolean(true) };
+        	assert.deepEqual(msgpack.decode(msgpack.encode(obj1)), msgpack.decode(msgpack.encode(obj2)));
+        });
+        
+        it('test primitive number / new Number()', ()=> {
+        	var obj1 = {'n1': 1234,             };
+        	var obj2 = {'n1': new Number(1234)  };
+        	assert.deepEqual(msgpack.decode(msgpack.encode(obj1)), msgpack.decode(msgpack.encode(obj2)));
+        });
+
+        it('test primitive string / new String()', ()=> {
+        	var obj1 = {'s1': 'abcd'             };
+        	var obj2 = {'s1': new String('abcd') };
+        	assert.deepEqual(msgpack.decode(msgpack.encode(obj1)), msgpack.decode(msgpack.encode(obj2)));
+        });
     });
 
     it('bson', () => {


### PR DESCRIPTION
msgpack - encode object bug

Please fill in this template.

- [x] Use a meaningful title for the pull request with prefix '(module|object|source_directory) [bugfix|feat|refactor|]', Such as `db, bugfix: ...`, `tools, feat: ...`
- [x] Test the change in your own code. (Compile and run.)
- [x] Add or edit tests to reflect the change. (Run with `fibjs test`.)
- [x] Ensure commits history clean, merge master/dev and clean meaningless commits by `git rebase`.