### PR TITLE
build, bugfix: fibjs build with alpine 3.13

### DIFF
--- a/dockerfiles/build-env-alpine/Dockerfile
+++ b/dockerfiles/build-env-alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.13
 
 LABEL AUTHOR="Richard"
 LABEL AUTHOR_EMAIL="richardo2016@gmail.com"
@@ -6,7 +6,7 @@ LABEL AUTHOR_EMAIL="richardo2016@gmail.com"
 RUN apk update && apk upgrade
 
 RUN apk update
-RUN apk add --no-cache clang clang-dev alpine-sdk xz dpkg ncurses && \
+RUN apk add --no-cache clang clang-dev alpine-sdk xz dpkg ncurses libx11 libx11-dev && \
     apk add --update --no-cache cmake && \
     apk add --update --no-cache linux-headers
 


### PR DESCRIPTION
dear maintainers, fibjs is great. but the current version of fibjs has some problems with the alpine environment.

I added the missing dependencies and conducted a build test.

for the stability of the software, it is recommended to use the specific version `eg: 3.13`  instead of latest rolling update.