### PR TITLE
core, fix: eliminate the key within the remove function.

### DIFF
--- a/fibjs/include/SimpleObject.h
+++ b/fibjs/include/SimpleObject.h
@@ -66,6 +66,7 @@ public:
             return CALL_RETURN_NULL;
 
         m_values[it->second].m_val.clear();
+        m_keys.erase(it);
         return 0;
     }
 


### PR DESCRIPTION
I think the logic for deleting a key is missing. Taking "info" as an example, after using the "remove" function like: 
```c++
g_info->remove("vender");
```
the vender display as `undefined`.
```bash
> .info
{
  "fibjs": "0.37.0-dev",
  ...
  "vender": undefined,  <-
  ...
}
```