### PR TITLE
fix: correct occured to occurred typo in error message

### DIFF
--- a/tools/translate/index.js
+++ b/tools/translate/index.js
@@ -188,7 +188,7 @@ function translate(text, opts) {
         return JSON.parse(res);
     }
     catch (e) {
-        console.error(`error occured when parsing result!`);
+        console.error(`error occurred when parsing result!`);
         console.error(`res is: `, res);
         throw new Error(e);
     }


### PR DESCRIPTION
Correct `occured` → `occurred` typo in console.error message.

1 file, 1 line fix.

---
GitHub: jydu_seven@outlook.com