### PR TITLE
webpty, fix: use global WebSocket instead of removed builtin ws module

### DIFF
--- a/samples/webpty/index.js
+++ b/samples/webpty/index.js
@@ -1,10 +1,9 @@
 const path = require("path");
 const http = require('http');
-const ws = require("ws");
 const child_process = require('child_process');
 
 const svr = new http.Server(8081, {
-    '/shell': ws.upgrade(socket => {
+    '/shell': WebSocket.upgrade(socket => {
         // 检测默认shell
         const defaultShell = process.env.SHELL || '/bin/bash';
         const isZsh = defaultShell.includes('zsh');
@@ -39,7 +38,7 @@ const svr = new http.Server(8081, {
 
             // Handle child process output (PTY combines stdout and stderr)
             child.stdout.on('data', (data) => {
-                if (socket.readyState === ws.OPEN) {
+                if (socket.readyState === WebSocket.OPEN) {
                     socket.send(JSON.stringify({
                         type: 'data',
                         data: data.toString()
@@ -49,7 +48,7 @@ const svr = new http.Server(8081, {
 
             // Handle child process exit
             child.on('exit', (code, signal) => {
-                if (socket.readyState === ws.OPEN) {
+                if (socket.readyState === WebSocket.OPEN) {
                     socket.send(JSON.stringify({
                         type: 'data',
                         data: `\r\nProcess exited with code: ${code}\r\n`
@@ -61,7 +60,7 @@ const svr = new http.Server(8081, {
             // Handle child process errors
             child.on('error', (error) => {
                 console.error('Child process error:', error);
-                if (socket.readyState === ws.OPEN) {
+                if (socket.readyState === WebSocket.OPEN) {
                     socket.send(JSON.stringify({
                         type: 'data',
                         data: `\r\nProcess error: ${error.message}\r\n`


### PR DESCRIPTION
The builtin 'ws' module was removed in 4cd13ad6 (WebSocket, feat: add WebSocket support and remove old ws module), so require("ws") fails with ENOENT on current dev builds.

Use the global WebSocket class (WebSocket.upgrade / WebSocket.OPEN) which exposes the same API, so the sample runs without extra deps.

Please fill in this template.

- [ ] Use a meaningful title for the pull request with prefix '(module|object|source_directory) [bugfix|feat|refactor|]', Such as `db, bugfix: ...`, `tools, feat: ...`
- [ ] Test the change in your own code. (Compile and run.)
- [ ] Add or edit tests to reflect the change. (Run with `fibjs test`.)
- [ ] Ensure commits history clean, merge master/dev and clean meaningless commits by `git rebase`.

Select type of change you made and delete the others:

If adding/changing one existing module or internal Object:
- [ ] Add/Change the corresponding `*.idl` file
- [ ] Run `fibjs ./tools/idlc.js` to auto-generate `*.h`, **never change it**

If removing one existing module or internal Object:
- [ ] Remove corresponding `*.h`, `*.idl`, `*.cpp`
- [ ] Remove all reference to it.

If adding internal js scripts:
- [ ] Add it to `fibjs/scripts`
- [ ] Run `fibjs ./tools/gen_script.js`
